### PR TITLE
Remove ` in include in file section

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Tested down to IE9 inclusive.
 
 The simplest and fastest way to get started is to include the minified CSS file in your project. Just add this snippet to the head of your html file:
 
-    `<link rel="stylesheet" href="https://raw.githubusercontent.com/colmtuite/framework/master/css/framework.min.css">`
+    <link rel="stylesheet" href="https://raw.githubusercontent.com/colmtuite/framework/master/css/framework.min.css">
 
 ## Contributing
 


### PR DESCRIPTION
Because of indent, this doesn't format properly and is overall not needed.

Note: should this be change to having ` and not being indented so as to show that it is HTML?